### PR TITLE
Improve embedding handling

### DIFF
--- a/app/embedder.py
+++ b/app/embedder.py
@@ -1,7 +1,7 @@
 from sentence_transformers import SentenceTransformer
-import torch
 
 model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')
 
 def embed_chunks(chunks: list[str]):
-    return model.encode(chunks, convert_to_tensor=True)
+    """Return embeddings for each chunk as NumPy arrays."""
+    return model.encode(chunks)

--- a/app/retriever.py
+++ b/app/retriever.py
@@ -1,8 +1,7 @@
-import torch
 from sklearn.metrics.pairwise import cosine_similarity
 
 def retrieve_relevant_chunk(query, chunks, chunk_embeddings, embedder):
-    query_embedding = embedder.encode([query], convert_to_tensor=True)
-    scores = cosine_similarity(query_embedding.cpu(), chunk_embeddings.cpu())[0]
+    query_embedding = embedder.encode([query])
+    scores = cosine_similarity(query_embedding, chunk_embeddings)[0]
     best_idx = scores.argmax()
     return chunks[best_idx]


### PR DESCRIPTION
## Summary
- simplify embedding logic to use NumPy arrays
- adjust retriever to match numpy embeddings

## Testing
- `python app/main.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68792e7533948320bca13b2278b45a83